### PR TITLE
feat: add 'view source' and 'copy' buttons

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,49 @@
+<header class="site-header" role="banner">
+
+  <div class="wrapper">
+    {%- assign default_paths = site.pages | map: "path" -%}
+    {%- assign page_paths = site.header_pages | default: default_paths -%}
+    <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
+
+    <div style="float: right;">
+      <a class="btn" href="https://github.com/jules-labs/jules-prompts/blob/main/{{ page.path }}" target="_blank">View Source</a>
+      <button class="btn" onclick="copyPrompt()">Copy</button>
+    </div>
+
+    {%- if page_paths -%}
+      <nav class="site-nav">
+        <input type="checkbox" id="nav-trigger" class="nav-trigger" />
+        <label for="nav-trigger">
+          <span class="menu-icon">
+            <svg viewBox="0 0 18 15" width="18px" height="15px">
+              <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z"/>
+            </svg>
+          </span>
+        </label>
+
+        <div class="trigger">
+          {%- for path in page_paths -%}
+            {%- assign my_page = site.pages | where: "path", path | first -%}
+            {%- if my_page.title -%}
+            <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
+            {%- endif -%}
+          {%- endfor -%}
+        </div>
+      </nav>
+    {%- endif -%}
+  </div>
+</header>
+
+<script>
+function copyPrompt() {
+  const content = document.querySelector('main.page-content').innerText;
+  navigator.clipboard.writeText(content)
+    .then(() => {
+      alert('Prompt copied to clipboard!');
+    })
+    .catch(err => {
+      console.error('Failed to copy text: ', err);
+      alert('Failed to copy prompt. See console for details.');
+    });
+}
+</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="{{ page.lang | default: site.lang | default: "en" }}">
+
+  {%- include head.html -%}
+
+  <body>
+
+    {%- include header.html -%}
+
+    <main class="page-content" aria-label="Content">
+      <div class="wrapper">
+        {{ content }}
+      </div>
+    </main>
+
+    {%- include footer.html -%}
+
+  </body>
+
+</html>


### PR DESCRIPTION
This commit adds 'View Source' and 'Copy' buttons to the header of each prompt page.

To achieve this, the default Jekyll `minima` theme is overridden by providing custom `_layouts/default.html` and `_includes/header.html` files.

- The 'View Source' button links directly to the corresponding markdown file on GitHub, allowing users to see the raw source and repository context.
- The 'Copy' button uses JavaScript to copy the rendered text content of the prompt to the user's clipboard, making it easy to paste into an agent's input.