### PR TITLE
This commit resolves a Jekyll build failure and cleans up the site's …

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,18 @@
+<footer class="site-footer h-card">
+  <data class="u-url" href="{{ "/" | relative_url }}"></data>
+
+  <div class="wrapper">
+
+    <div class="footer-col-wrapper">
+      <div class="footer-col">
+        <p>{{ site.description | escape }}</p>
+      </div>
+    </div>
+
+    <div class="social-links">
+      {%- include social.html -%}
+    </div>
+
+  </div>
+
+</footer>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {%- seo -%}
   <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
-  {%- feed_meta -%}
   {%- if jekyll.environment == 'production' and site.google_analytics -%}
     {%- include google-analytics.html -%}
   {%- endif -%}


### PR DESCRIPTION
…include files.

The build was failing due to an `Unknown tag 'feed_meta'` error. This was caused by the `_includes/head.html` file containing a tag for the `jekyll-feed` plugin, which is not enabled in the project. The tag has been removed.

Additionally, this commit adds a `_includes/footer.html` and an empty `_includes/social.html` to prevent future build errors from missing includes. The footer was also modified to remove a dependency on the `jekyll-feed` plugin.

These changes should result in a clean Jekyll build.