### PR TITLE
fix: Correct sidebar layout and highlight style

### DIFF
--- a/_prompts/task_audit_repo.md
+++ b/_prompts/task_audit_repo.md
@@ -1,4 +1,5 @@
 ---
+layout: default
 title: Audit Repository
 description: To conduct a comprehensive, evidence-based audit of a repository or live website.
 ---

--- a/_prompts/task_curate_repo.md
+++ b/_prompts/task_curate_repo.md
@@ -1,4 +1,5 @@
 ---
+layout: default
 title: Curate Repository
 description: To analyze an unknown repository, make safe, reversible improvements, and provide a clear report.
 ---

--- a/_prompts/task_fix_and_refine.md
+++ b/_prompts/task_fix_and_refine.md
@@ -1,4 +1,5 @@
 ---
+layout: default
 title: Fix and Refine
 description: To transform a prototype or demo-quality project into a production-grade application.
 ---

--- a/_prompts/task_harden_repo_initial.md
+++ b/_prompts/task_harden_repo_initial.md
@@ -1,4 +1,5 @@
 ---
+layout: default
 title: Harden Repository (Initial)
 description: To perform a one-time, comprehensive hardening and baselining pass on a new or unmaintained repository.
 ---

--- a/_prompts/task_harden_repo_iterative.md
+++ b/_prompts/task_harden_repo_iterative.md
@@ -1,4 +1,5 @@
 ---
+layout: default
 title: Harden Repository (Iterative)
 description: To perform ongoing, iterative improvements to a repository that has already been hardened.
 ---

--- a/_prompts/task_update_dependencies.md
+++ b/_prompts/task_update_dependencies.md
@@ -1,4 +1,5 @@
 ---
+layout: default
 title: Update Dependencies
 description: To update a project's dependencies to their latest compatible versions.
 ---

--- a/_prompts/template_master_prompt.md
+++ b/_prompts/template_master_prompt.md
@@ -1,4 +1,5 @@
 ---
+layout: default
 title: Master Prompt Template
 description: The master template used to create and standardize all other prompts. It is not intended for direct use but serves as a 'golden copy' for prompt engineering.
 ---

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -48,10 +48,10 @@ body {
 }
 
 .file-tree li a.active {
-  background-color: #e8f0fe;
-  color: #1c6ab5;
+  background-color: #f0f0f0;
+  color: #000000;
   font-weight: 600;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
 }
 
 .container {


### PR DESCRIPTION
This commit addresses two user-reported issues:
1.  A bug where the sidebar would disappear on prompt detail pages.
2.  A request to change the sidebar's active link highlight style.

The missing sidebar was caused by the default layout not being applied to the documents in the `prompts` collection. This has been fixed by explicitly adding `layout: default` to the front matter of all prompt files.

The active link highlight style has been updated in `assets/css/style.scss` to use a grayscale "lift-up" effect with a box-shadow, as requested by the user.