### PR TITLE
feat: Add Turbo Drive for faster navigation

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,4 +2,5 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>{{ page.title | default: site.title | default: "Jules Prompts" }}</title>
+<script src="https://cdn.jsdelivr.net/npm/@hotwired/turbo@8.0.13/dist/turbo.es2017-umd.js" defer></script>
 <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">


### PR DESCRIPTION
This commit adds the Turbo Drive JavaScript library to the project to create a smoother, single-page application-like navigation experience.

By intercepting link clicks and fetching new pages in the background, Turbo Drive eliminates the "flash" of a full-page reload, making the site feel significantly faster and more responsive. This directly addresses the user's feedback about the screen flashing on navigation.