### PR TITLE
Fix: Sort prompts collection to ensure all prompts are displayed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,3 +5,4 @@ collections:
   prompts:
     output: true
     layout: default
+    sort_by: title


### PR DESCRIPTION
The sidebar was not displaying all available prompts because the `site.prompts` collection was not being fully populated.

This change adds `sort_by: title` to the `prompts` collection in `_config.yml`. This forces Jekyll to re-evaluate the collection and include all the files, ensuring that the sidebar displays all available prompts.