### PR TITLE
docs: make prompt library pin-ready

### DIFF
--- a/PROMPTS_GUIDE.md
+++ b/PROMPTS_GUIDE.md
@@ -83,7 +83,7 @@ This prompt guides the AI to identify the project's intended purpose, fix bugs, 
 ---
 
 
-### [`task_build_from_plan.md`]({% link _prompts/task_build_from_plan.md%})
+### [`task_build_from_plan.md`]({% link _prompts/task_build_from_plan.md %})
 **Purpose:** To analyze a repository's blueprint/plan and current state, and iteratively implement the next logical steps to build a robust, production-grade system.
 
 This prompt guides the AI to act as a lead developer, taking a project plan and executing it while using web research to make informed technical decisions and improvements.

--- a/PROMPTS_GUIDE.md
+++ b/PROMPTS_GUIDE.md
@@ -5,7 +5,7 @@ permalink: /prompts-guide/
 ---
 # Jules Prompt Library Guide
 
-This repository contains a curated library of pre-made, machine-readable task prompts that empower an AI software engineer like Jules to turn user intent into production-grade work. This guide explains the purpose of each prompt and provides a recommended workflow for using them together.
+This repository contains a curated library of pre-made, machine-readable task prompts that help an AI software engineer like Jules turn user intent into well-scoped, verifiable work. This guide explains the purpose of each prompt and provides a recommended workflow for using them together.
 
 ## Prompt Library
 
@@ -116,7 +116,7 @@ This prompt is designed for situations where the content and structure of a repo
 
 ## Recommended Workflow
 
-The prompts in this library are designed to be complementary and can be used together in a logical sequence. Here is a recommended workflow for taking a new or unmaintained project to a production-ready state:
+The prompts in this library are designed to be complementary and can be used together in a logical sequence. Here is a recommended workflow for taking a new or unmaintained project toward a more maintainable, verifiable state:
 
 1.  **Audit the repository.**
     *   **Prompt:** `task_audit_repo.md`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![GitHub stars](https://img.shields.io/github/stars/melbinjp/jules-prompts?style=social)](https://github.com/melbinjp/jules-prompts)
 
-A curated library of pre-made, machine-readable task prompts that let Jules (or any agent) — and humans — turn intent into production-grade work.
+A curated library of pre-made, machine-readable task prompts that help Jules (or any agent) — and humans — turn intent into well-scoped, verifiable engineering work.
 
 ## Getting Started
 
@@ -29,8 +29,21 @@ If you are a human interacting with an AI agent, the simplest way to use a promp
 AI agents can use the `prompts.json` file to discover and fetch prompts.
 
 1.  **Discover:** Fetch and parse `prompts.json` to get a list of available prompts.
-2.  **Select:** Choose a prompt based on its title and description.
-3.  **Execute:** Fetch the content of the markdown file specified in the `path` field and use it as the master instruction.
+2.  **Select:** Choose a prompt based on its title, description, or category.
+3.  **Execute:** Fetch the rendered prompt from its `url`, or read the source markdown at its `source_path`, then use it as the task instruction.
+
+## Keeping the library current
+
+New prompts are useful when they cover a recurring task that the existing set
+does not handle clearly. Do not add prompts only to increase the count.
+
+When adding or revising a prompt:
+
+1. Keep its YAML front matter aligned with the other files in `_prompts/`.
+2. Update `PROMPTS_GUIDE.md` when its purpose or recommended use changes.
+3. Update `workflow.json` only when the recommended sequence changes.
+4. Keep `AGENTS.md`, this README, and the generated `prompts.json` fields aligned.
+5. Test the Jekyll site and JSON endpoint before merging when the site structure changes.
 
 ## Contributing
 


### PR DESCRIPTION
## What changed

- Corrected the programmatic usage instructions to match the actual `prompts.json` fields: `url` and `source_path`.
- Added a small maintenance guide explaining when to add prompts and which index/docs files should stay aligned.
- Replaced broad production-grade wording with a more accurate description of reusable, verifiable engineering prompts.

## Why

The repository is being pinned as a reference library. These changes make the first-use path accurate without adding prompts just to increase the collection size.

## Validation

- Reviewed all current prompt front matter and manifest fields.
- Confirmed the working tree still excludes the unrelated generated `events.json` and `pulls.json` files.
