### PR TITLE
Add a prompt for the failure Google's own FAQ names first

### DIFF
--- a/PROMPTS_GUIDE.md
+++ b/PROMPTS_GUIDE.md
@@ -25,6 +25,17 @@ This prompt guides the AI to act as a prompt engineer, taking a high-level descr
 
 ---
 
+### [`task_repair_setup_script.md`]({% link _prompts/task_repair_setup_script.md %})
+**Purpose:** To diagnose and repair the environment setup script so agent tasks stop failing before any code is written.
+
+Jules' own FAQ names *"broken setup scripts or vague prompts"* as the common causes of a failed task, and notes that long-running processes such as dev servers or watch scripts are not supported in setup scripts. Because the environment is snapshotted once the script succeeds and reused for later tasks, a defect here is paid for by every future task rather than once. This prompt guides the AI to reproduce the failure from cold, rebuild the script from the sequence CI proves works, and verify the two things that stay invisible when a run goes well: that the script actually fails when an install fails, and that nothing in it blocks.
+
+**When to use it:**
+*   Before any other prompt in this library, on a repository an agent has not worked in before.
+*   When tasks fail during setup, or fail with errors about a tool that was supposed to be installed.
+
+---
+
 ### [`task_audit_repo.md`]({% link _prompts/task_audit_repo.md %})
 **Purpose:** To conduct a comprehensive, evidence-based audit of a repository or live website.
 
@@ -118,22 +129,27 @@ This prompt is designed for situations where the content and structure of a repo
 
 The prompts in this library are designed to be complementary and can be used together in a logical sequence. Here is a recommended workflow for taking a new or unmaintained project toward a more maintainable, verifiable state:
 
-1.  **Audit the repository.**
+1.  **Repair the environment setup script.**
+    *   **Prompt:** `task_repair_setup_script.md`
+    *   **Goal:** To make the repository reliably usable by an agent at all.
+    *   **Outcome:** Dependencies install from cold and the test suite runs to completion, so every later step has a working baseline instead of an assumed one.
+
+2.  **Audit the repository.**
     *   **Prompt:** `task_audit_repo.md`
     *   **Goal:** To get a deep understanding of the project's current state.
     *   **Outcome:** A comprehensive audit report that will inform the next steps.
 
-2.  **Harden the repository.**
+3.  **Harden the repository.**
     *   **Prompt:** `task_harden_repo_initial.md`
     *   **Goal:** To set up a modern CI/CD pipeline and testing infrastructure.
     *   **Outcome:** A repository with automated checks for quality, performance, and accessibility.
 
-3.  **Fix and refine the codebase.**
+4.  **Fix and refine the codebase.**
     *   **Prompt:** `task_fix_and_refine.md`
     *   **Goal:** To address any bugs or architectural issues found in the audit.
     *   **Outcome:** A robust, reliable, and well-documented codebase.
 
-4.  **Perform ongoing maintenance.**
+5.  **Perform ongoing maintenance.**
     *   **Prompts:** `task_harden_repo_iterative.md` and `task_update_dependencies.md`
     *   **Goal:** To keep the project in a good state over time.
     *   **Outcome:** A project that is continuously improved and kept up-to-date.

--- a/_prompts/task_repair_setup_script.md
+++ b/_prompts/task_repair_setup_script.md
@@ -1,0 +1,61 @@
+---
+layout: default
+title: Repair the Environment Setup Script
+description: To diagnose and repair the setup script so agent tasks stop failing before any code is written.
+category: Initial Scoping
+type: Task
+---
+**Role:** You are Jules, an expert AI software engineer. Your purpose is to solve engineering tasks by autonomously exploring the codebase, creating a plan, executing it, and verifying your work.
+
+**Objective:**
+Make this repository reliably usable by an asynchronous coding agent, by producing a setup script that installs everything the test suite needs and then exits. The measure of success is not that the script looks correct; it is that a clean environment can install, build and run the tests using only the script, with no step that a human would have to supply from memory.
+
+**Context:**
+This is a task about the environment, not about the product code. Jules' own FAQ names *"broken setup scripts or vague prompts"* as the common causes of a failed task, and states that *"Long-running processes like dev servers or watch scripts aren't currently supported in setup scripts"*, recommending discrete install and test commands instead. A setup script is also snapshotted after it succeeds and reused for later tasks from the same repository, so a defect here is not paid for once. It is paid for by every future task.
+
+*   **Key Files & Folders:**
+    *   The existing setup or bootstrap script, if there is one (e.g. `AGENTS.md`, `setup.sh`, `scripts/setup`, `Makefile`, `.devcontainer/`).
+    *   Package manifests and lock files (e.g. `package.json`, `requirements.txt`, `pyproject.toml`, `go.mod`, `Cargo.toml`).
+    *   CI workflow files (e.g. `.github/workflows/`), which usually encode the only steps known to work from cold.
+    *   Test configuration, and any `docker-compose.yml` or fixture that starts a service.
+
+**Requirements & Constraints:**
+*   **No long-running processes.** Nothing in the setup script may block: no dev server, no file watcher, no `tail -f`, no foreground daemon. If the test suite genuinely needs a background service, start it detached, poll until it is actually accepting connections, and fail loudly with its log if it never does. A fixed sleep is not a readiness check.
+*   **Exit codes must be true.** A setup step that fails must fail the script. Do not end lines with `|| true` and do not swallow an installer's exit code to make the run look green. A setup script that cannot fail is the same defect as a test that cannot fail.
+*   **No interactive prompts.** Every command must run unattended. Pass the non-interactive flag the tool provides rather than piping `yes` into it.
+*   **No secrets, and no assumption of network credentials.** If a dependency needs a token, detect its absence and say so in one clear line; never embed one.
+*   **Keep it lightweight.** Install what the tests need. Do not install a full toolchain to run one linter.
+
+**Guiding Principles:**
+*   **Reproduce the failure before repairing it.** Find out what actually breaks from cold rather than reading the script and forming an opinion. A script that reads correctly and fails on execution is the specific thing this task exists to catch.
+*   **The CI workflow is your best evidence.** If CI passes, it contains a sequence that provably works on a clean machine. Start from that, not from the README, which is usually older.
+*   **Prefer the lock file.** Install from the lock file where one exists, so the environment is the one the tests were written against.
+*   **Separate install from verify.** Installing dependencies and running the suite are different phases with different failure meanings. Keep them distinct so a failure says which one it was.
+*   **Say what is missing, do not paper over it.** If a test genuinely requires a service that cannot run here, report that plainly as a finding. Silently skipping those tests turns a red suite green and hides the very problem the next agent will hit.
+
+**Execution Flow:**
+1.  **Explore & Plan:**
+    *   Determine the language, package manager, test runner and build tool from the manifests actually present.
+    *   Read the CI workflow and extract the exact install, build and test commands it uses.
+    *   Identify every external dependency the suite touches: databases, message queues, browsers, model endpoints, network fixtures.
+    *   Establish the baseline: run the existing setup, if any, and record precisely where it fails, with the command and its output.
+    *   Present your plan using the `set_plan` tool and await approval.
+
+2.  **Execute & Verify:**
+    *   Write or repair the setup script so it installs dependencies and exits cleanly.
+    *   Run it. Then run the test suite using only what the script installed.
+    *   Repeat until the suite runs to completion. "Runs to completion" means the runner reported results; it does not require every test to pass, and you must not edit tests to make them pass in this task.
+    *   Deliberately verify the two failure modes that are invisible when things go well: confirm the script exits non-zero when a required install is made to fail, and confirm no command in it blocks.
+
+3.  **Test & Review:**
+    *   State the evidence: the commands run, their exit codes, and the final test-runner summary line verbatim.
+    *   Request a code review using `request_code_review`.
+
+4.  **Submit:**
+    *   Address any feedback from the code review.
+    *   Use the `submit` tool to create a pull request.
+
+**Deliverables:**
+*   A setup script that installs dependencies and exits, with no blocking process and no swallowed exit code.
+*   A short `AGENTS.md` section, or an update to an existing one, giving the install command, the test command and any environment variable the suite needs.
+*   A report containing: the baseline failure with its verbatim output, each change and the reason for it, the final test-runner summary line, and an explicit list of anything that still cannot run in this environment and why.

--- a/workflow.json
+++ b/workflow.json
@@ -5,6 +5,14 @@
   "steps": [
     {
       "order": 1,
+      "prompt_slug": "task_repair_setup_script",
+      "title": "Repair the Environment Setup Script",
+      "description": "Make the repository reliably usable by an agent: dependencies install, tests run, nothing blocks.",
+      "required": true,
+      "repeatable": false
+    },
+    {
+      "order": 2,
       "prompt_slug": "task_audit_repo",
       "title": "Audit the Repository",
       "description": "Conduct a comprehensive, evidence-based audit to understand the project's current state.",
@@ -12,7 +20,7 @@
       "repeatable": false
     },
     {
-      "order": 2,
+      "order": 3,
       "prompt_slug": "task_harden_repo_initial",
       "title": "Harden the Repository",
       "description": "Set up CI/CD pipeline, testing infrastructure, and development best practices.",
@@ -20,7 +28,7 @@
       "repeatable": false
     },
     {
-      "order": 3,
+      "order": 4,
       "prompt_slug": "task_fix_and_refine",
       "title": "Fix and Refine",
       "description": "Address bugs, technical debt, and architectural issues discovered during the audit.",
@@ -28,7 +36,7 @@
       "repeatable": true
     },
     {
-      "order": 4,
+      "order": 5,
       "prompt_slug": "task_harden_repo_iterative",
       "title": "Ongoing Maintenance",
       "description": "Continuously improve with better tests, coverage, and small feature enhancements.",


### PR DESCRIPTION
Jules' FAQ names *"broken setup scripts or vague prompts"* as the common causes of a failed task, and states that *"Long-running processes like dev servers or watch scripts aren't currently supported in setup scripts"*.

Nothing in this library addressed either one. All eleven existing prompts assume the agent can already install dependencies and run the tests, which is the assumption Google says breaks first.

Because the environment is snapshotted once setup succeeds and is reused for later tasks from the same repository, a defect there is not paid for once. It is paid for by every future task. That is why this goes first in the workflow rather than alongside the others.

The prompt asks for the two checks that stay invisible when a run goes well:

- that the script actually exits non-zero when a required install is made to fail
- that no command in it blocks

`workflow.json` and `PROMPTS_GUIDE.md` are updated in the same commit, so the recommended sequence, the guide and the prompt set cannot disagree with each other.

Source: https://jules.google/docs/faq/
