### PR TITLE
Add the other half of the FAQ's named failures, and document a prompt that was missing

### DIFF
--- a/PROMPTS_GUIDE.md
+++ b/PROMPTS_GUIDE.md
@@ -36,6 +36,17 @@ Jules' own FAQ names *"broken setup scripts or vague prompts"* as the common cau
 
 ---
 
+### [`task_scope_a_vague_issue.md`]({% link _prompts/task_scope_a_vague_issue.md %})
+**Purpose:** To turn an underspecified bug report into a reproducible, testable task before any fix is attempted.
+
+The other half of what Jules' FAQ names as the common causes of a failed task. The failure is quiet rather than loud: given "the login is broken", an agent does not stop and ask, it guesses what broken means and builds on the guess, so the work looks complete and fixes something nobody reported. This prompt produces a minimal reproduction, a failing test that is checked to fail for the reported reason, and an explicit list of every ambiguity in the original issue with the reading taken for each. It deliberately produces no fix.
+
+**When to use it:**
+*   Before handing a thin bug report to an agent, especially one written by someone who is not the maintainer.
+*   When a previous agent attempt "fixed" something that was not what was reported.
+
+---
+
 ### [`task_audit_repo.md`]({% link _prompts/task_audit_repo.md %})
 **Purpose:** To conduct a comprehensive, evidence-based audit of a repository or live website.
 
@@ -45,6 +56,17 @@ This prompt guides the AI to produce a detailed report on the project's current 
 *   When you are new to a project and need to understand how it works.
 *   Before starting a major refactoring or migration project.
 *   As a periodic health check for a project.
+
+---
+
+### [`task_build_api_frontend.md`]({% link _prompts/task_build_api_frontend.md %})
+**Purpose:** To build a modern, functional frontend for an application based on its backend API.
+
+This prompt guides the AI to read an existing backend, from a live endpoint, its API documentation, or its source, and build a frontend that actually matches it. It is aimed at the common case where a frontend is missing, outdated, or has drifted away from the API it is supposed to call.
+
+**When to use it:**
+*   When a working backend has no usable interface in front of it.
+*   When the frontend and the API have diverged and the interface needs rebuilding against what the API really exposes.
 
 ---
 

--- a/_prompts/task_scope_a_vague_issue.md
+++ b/_prompts/task_scope_a_vague_issue.md
@@ -1,0 +1,62 @@
+---
+layout: default
+title: Scope a Vague Issue
+description: To turn an underspecified bug report into a reproducible, testable task before any fix is attempted.
+category: Initial Scoping
+type: Task
+---
+**Role:** You are Jules, an expert AI software engineer. Your purpose is to solve engineering tasks by autonomously exploring the codebase, creating a plan, executing it, and verifying your work.
+
+**Objective:**
+Take an issue that does not say enough to act on, and turn it into a specification that does: an exact reproduction, the observed behaviour, the expected behaviour, and a failing test that captures the difference. Produce no fix in this task. The deliverable is a task that can be handed on with nothing left to guess.
+
+**Context:**
+Jules' own FAQ names *"broken setup scripts or vague prompts"* as the common causes of a failed task. The failure is quiet rather than loud: given "the login is broken", an agent does not stop and ask, it guesses what broken means and builds on the guess. The work then looks complete, passes review, and fixes something nobody reported. Scoping is cheap and the wrong fix is not, so this step exists to be done before the expensive one.
+
+*   **The issue:** `<ISSUE_URL_OR_TEXT>`
+*   **Key Files & Folders:**
+    *   The issue tracker entry and any linked discussion, log or screenshot.
+    *   The test suite and its fixtures, which show how this project already reproduces things.
+    *   Recent history touching the named area (`git log`, `git blame`), which often contains the change that introduced the behaviour.
+
+**Requirements & Constraints:**
+*   **Do not fix anything.** No behaviour change in this task. A repair made while the problem is still ambiguous is the failure this prompt exists to prevent.
+*   **Reproduce it, or say plainly that you could not.** An unreproduced report may be stated as unreproduced, with exactly what you tried. Never present a guess as a diagnosis.
+*   **Every claim carries evidence.** A file and line, a command and its output, or a log excerpt. "It appears that" is not a finding.
+*   **The failing test must fail for the reported reason.** A test that fails for an unrelated reason is worse than none, because it will go green when something else changes and be read as a fix.
+*   **Do not widen the scope.** Other defects found on the way are recorded as separate findings, not folded into this one.
+
+**Guiding Principles:**
+*   **Separate the report from the behaviour.** What the reporter said, what the software actually does, and what it should do are three different statements, and a vague issue is usually one of them standing in for all three.
+*   **Name the gap rather than filling it.** Where the issue is silent, say so explicitly: version, environment, input, and which of several plausible readings you took. That list is the most useful part of the output.
+*   **Ask the codebase before asking the reporter.** Most ambiguity is resolvable from the tests, the types and the history. Reserve questions for what genuinely only the reporter knows.
+*   **Prefer the smallest reproduction.** Reduce it until every remaining step is necessary. The steps you were able to delete are themselves evidence about where the fault is not.
+*   **Expected behaviour needs a source.** Point at documentation, a test, a type signature or a specification. If none exists, say that the expected behaviour is undefined, because that is a finding about the project rather than about the bug.
+
+**Execution Flow:**
+1.  **Explore & Plan:**
+    *   Read the issue and list precisely what it does not say.
+    *   Locate the code paths it could plausibly refer to, and enumerate the distinct readings the wording allows.
+    *   Establish a baseline: confirm the suite runs cleanly before you add anything.
+    *   Present your plan using the `set_plan` tool and await approval.
+
+2.  **Execute & Verify:**
+    *   Attempt the reproduction. Record each attempt, including the ones that failed to reproduce.
+    *   Once reproduced, reduce it to the smallest sequence that still shows the behaviour.
+    *   Write a failing test that captures the difference between observed and expected. Run it and confirm it fails, then confirm the rest of the suite still behaves as it did at baseline.
+    *   Verify the test fails for the right reason: change the suspected cause and confirm the test's outcome follows it, so a coincidence is ruled out.
+
+3.  **Test & Review:**
+    *   State the reproduction, the failing test, its verbatim failure output, and the list of assumptions you had to make.
+    *   Request a code review using `request_code_review`.
+
+4.  **Submit:**
+    *   Address any feedback from the code review.
+    *   Use the `submit` tool to open a pull request containing the failing test and the scoping report, marked clearly as a reproduction rather than a fix.
+
+**Deliverables:**
+*   A minimal reproduction with exact steps, environment and input.
+*   A failing test, with its verbatim failure output and the check that it fails for the reported reason.
+*   Statements of observed and expected behaviour, the latter with its source.
+*   An explicit list of every ambiguity in the original issue and the reading you took for each, so the next reader can correct you cheaply.
+*   Any separate defects found on the way, recorded as their own findings and not fixed here.


### PR DESCRIPTION
Jules' FAQ names *"broken setup scripts or vague prompts"* as the common causes of a failed task. #27 covered the setup-script half. This is the other one.

The failure is quiet rather than loud. Given "the login is broken", an agent does not stop and ask, it guesses what broken means and builds on the guess, so the work looks complete and fixes something nobody reported.

`task_scope_a_vague_issue` produces:

- a minimal reproduction, with the attempts that failed to reproduce recorded too
- a failing test, plus a check that it fails for the **reported** reason rather than by coincidence
- an explicit list of every ambiguity in the original issue and the reading taken for each

It deliberately produces no fix, so the expensive step is never taken while the problem is still ambiguous.

**Not added to `workflow.json`** on purpose: that sequence is "New Repository to Production", and scoping an incoming issue is a recurring activity rather than a step in it.

**Also fixes an existing gap.** `task_build_api_frontend` had a prompt file but no entry in `PROMPTS_GUIDE.md`. The README asks for the guide and the prompt set to stay aligned, and `prompts.json` is fetched by agents, so an index that disagrees with the library is a defect rather than a cosmetic gap. Now 13 prompts and 13 guide entries.

Source: <https://jules.google/docs/faq/>
