### PR TITLE
Make "the guide and the prompt set stay aligned" checkable instead of remembered

### DIFF
--- a/.github/workflows/library-integrity.yml
+++ b/.github/workflows/library-integrity.yml
@@ -1,0 +1,32 @@
+name: Library integrity
+
+# The prompt set, PROMPTS_GUIDE.md and workflow.json are three views of one library, and the
+# README asks for them to stay aligned. They had already drifted once. This makes the rule
+# checkable instead of remembered.
+#
+# Deliberately has no `continue-on-error` and no step that swallows an exit code: a check that
+# cannot fail is indistinguishable from one that was never run.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - '_prompts/**'
+      - 'PROMPTS_GUIDE.md'
+      - 'workflow.json'
+      - 'scripts/check_library_integrity.py'
+      - '.github/workflows/library-integrity.yml'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: The library must agree with itself
+        run: python scripts/check_library_integrity.py

--- a/scripts/check_library_integrity.py
+++ b/scripts/check_library_integrity.py
@@ -1,0 +1,99 @@
+"""Does this library agree with itself?
+
+    python scripts/check_library_integrity.py
+
+`prompts.json` is fetched by agents rather than read by people, and `PROMPTS_GUIDE.md` is
+what a human reads first. The README asks for the prompt set, the guide, and the workflow to
+stay aligned. Nothing checked that they did, and they had already drifted:
+`task_build_api_frontend` shipped with a prompt file and no guide entry.
+
+That is a small gap with an awkward property. A library whose own index is incomplete is
+making a claim it cannot support, and this one is specifically sold as machine-readable, so
+the index is the product rather than documentation about it.
+
+**This check is written to be able to fail.** No step in it swallows an exit code and there
+is no `continue-on-error` on the workflow that runs it. A verification that cannot fail is
+indistinguishable from one that was never run.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PROMPTS = ROOT / "_prompts"
+GUIDE = ROOT / "PROMPTS_GUIDE.md"
+WORKFLOW = ROOT / "workflow.json"
+
+# Every prompt carries YAML front matter, and `prompts.json` is generated from these fields.
+# A missing one renders as an empty string in the JSON rather than an error, which is the
+# quiet kind of breakage this file exists to make loud.
+REQUIRED_FIELDS = ("layout", "title", "description", "category", "type")
+
+GUIDE_ENTRY = re.compile(r"^### \[`([a-z0-9_]+)\.md`\]", re.M)
+FIELD = re.compile(r"^([a-z_]+):", re.M)
+
+
+def front_matter(text: str) -> dict:
+    if not text.startswith("---"):
+        return {}
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}
+    block = text[3:end]
+    return {m.group(1): True for m in FIELD.finditer(block)}
+
+
+def main() -> int:
+    problems: list[str] = []
+
+    files = sorted(p.stem for p in PROMPTS.glob("*.md"))
+    if not files:
+        print("BLIND: no prompt files found at all. Refusing to report a pass.")
+        return 1
+
+    guide = GUIDE.read_text(encoding="utf-8")
+    documented = sorted(set(GUIDE_ENTRY.findall(guide)))
+
+    for slug in files:
+        if slug not in documented:
+            problems.append(f"{slug}.md has no entry in PROMPTS_GUIDE.md")
+    for slug in documented:
+        if slug not in files:
+            problems.append(f"PROMPTS_GUIDE.md documents {slug}.md, which does not exist")
+
+    for p in sorted(PROMPTS.glob("*.md")):
+        fm = front_matter(p.read_text(encoding="utf-8"))
+        if not fm:
+            problems.append(f"{p.name} has no YAML front matter, so it will not render")
+            continue
+        for field in REQUIRED_FIELDS:
+            if field not in fm:
+                problems.append(f"{p.name} front matter is missing '{field}'")
+
+    steps = json.loads(WORKFLOW.read_text(encoding="utf-8"))["steps"]
+    for s in steps:
+        if s["prompt_slug"] not in files:
+            problems.append(f"workflow.json step {s['order']} points at "
+                            f"{s['prompt_slug']}, which is not in _prompts/")
+    orders = [s["order"] for s in steps]
+    if orders != list(range(1, len(steps) + 1)):
+        problems.append(f"workflow.json step orders are {orders}, not 1..{len(steps)}")
+
+    # Say what was READ, not only what was wrong. A check that reports "OK" without its
+    # coverage cannot be told apart from one whose globs stopped matching.
+    print(f"checked {len(files)} prompt(s), {len(documented)} guide entry(ies), "
+          f"{len(steps)} workflow step(s)")
+    if problems:
+        print(f"\n{len(problems)} problem(s):")
+        for p in problems:
+            print(f"  - {p}")
+        return 1
+    print("the prompt set, the guide and the workflow agree")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The README asks for the prompt set, `PROMPTS_GUIDE.md` and `workflow.json` to stay aligned. They had already drifted: `task_build_api_frontend` shipped with a prompt file and no guide entry, and nothing noticed. (#28 fixed that instance.)

The gap has an awkward property. `prompts.json` is fetched by agents rather than read by people, so here the index **is** the product, not documentation about it. A library sold as machine-readable whose own index is incomplete is making a claim it cannot support.

The check verifies:

- every prompt has a guide entry, and every guide entry has a prompt
- every prompt carries the front matter fields `prompts.json` is generated from (a missing one renders as an empty string in the JSON rather than an error)
- every `workflow.json` step points at a slug that exists, and the orders are contiguous

Two things it does on purpose:

- **It prints what it read** (`checked 13 prompt(s), 13 guide entry(ies), 5 workflow step(s)`), so a pass cannot be confused with a run whose globs quietly stopped matching.
- **It can fail.** No `continue-on-error`, no swallowed exit code. Tested in both directions: `rc=0` on the current tree, `rc=1` with a guide entry removed, and `rc=1` again with a guide entry pointing at a file that does not exist.
