### PR TITLE
Two more prompts for how agents actually fail, not how tasks are meant to go

### DIFF
--- a/PROMPTS_GUIDE.md
+++ b/PROMPTS_GUIDE.md
@@ -127,6 +127,28 @@ This prompt guides the AI to act as a lead developer, taking a project plan and 
 
 ---
 
+### [`task_review_an_agent_pr.md`]({% link _prompts/task_review_an_agent_pr.md %})
+**Purpose:** To review a pull request an agent wrote, against the failure modes agents actually have.
+
+Agent-written pull requests fail differently from human ones, so a review habit built on human mistakes misses them. The danger named by practitioners is not that the code is bad but that it reads as finished: correct style, sensible names, a confident description, and tests that pass because they assert what the code does rather than what it should do. This prompt checks each claim the pull request makes about itself, and its central move is to break the code a new test covers and confirm the test goes red, because a test that passes against both the fixed and the broken version is not evidence of anything.
+
+**When to use it:**
+*   Before merging any pull request written by an agent, including your own.
+*   When a change looks complete and you cannot say precisely which requirement each part of it satisfies.
+
+---
+
+### [`task_isolate_tests_from_services.md`]({% link _prompts/task_isolate_tests_from_services.md %})
+**Purpose:** To make a test suite runnable in an agent's sandbox by removing its dependence on services it cannot start.
+
+A suite that assumes a database, a broker or a live third-party API does not fail clearly inside an agent's environment. It fails partway through with a connection error, which the agent then reports as unrelated to its own changes before carrying on, so the work looks reviewed and was never tested. This prompt isolates the suite at the seams the project already has, and verifies the isolation twice over: by pointing the services at a dead port and re-running, and by reconciling the collected test count before and after so nothing has quietly stopped running.
+
+**When to use it:**
+*   When agent tasks fail with connection errors, or when an agent reports test failures as unrelated.
+*   Before handing a repository to an agent for the first time, alongside `task_repair_setup_script.md`.
+
+---
+
 ### [`task_update_dependencies.md`]({% link _prompts/task_update_dependencies.md %})
 **Purpose:** To update a project's dependencies to their latest compatible versions.
 

--- a/_prompts/task_isolate_tests_from_services.md
+++ b/_prompts/task_isolate_tests_from_services.md
@@ -1,0 +1,59 @@
+---
+layout: default
+title: Isolate Tests from External Services
+description: To make a test suite runnable in an agent's sandbox by removing its dependence on services it cannot start.
+category: Maintenance
+type: Task
+---
+**Role:** You are Jules, an expert AI software engineer. Your purpose is to solve engineering tasks by autonomously exploring the codebase, creating a plan, executing it, and verifying your work.
+
+**Objective:**
+Make the test suite runnable from cold in an environment with no database, no message broker, no external API and no developer laptop behind it. Every test must either run without a live service or be excluded by a named marker that says which service it needs and why.
+
+**Context:**
+This is the failure that turns a working repository into one an agent cannot help with. A suite that assumes a Postgres container, a Redis instance, a seeded staging database or a live third-party API does not fail with a clear message; it fails with a connection error partway through, and the agent then reports the failures as "unrelated to our changes" and carries on. The change looks reviewed and was never tested.
+
+*   **Key Files & Folders:**
+    *   Test configuration and fixtures (`conftest.py`, `setup.js`, `TestBase`, factories, seeders).
+    *   `docker-compose.yml`, `.env.test`, CI service definitions, testcontainers usage.
+    *   Any test helper that opens a socket, reads a URL from the environment, or calls a client library constructor at import time.
+
+**Requirements & Constraints:**
+*   **Do not change what a test asserts.** This task changes how a test gets its dependencies, never what it expects. If a test can only pass by weakening its assertion, leave it failing and report it.
+*   **No test may be silently skipped.** Every exclusion carries an explicit marker and a reason readable at the point of exclusion. A suite that quietly runs 40 of 200 tests and reports green is worse than one that fails honestly.
+*   **The default invocation must be the isolated one.** If running the plain test command still needs a database, the work is not done, whatever a flag can do.
+*   **Preserve a way to run the full suite** against real services, and document the command. Isolation must not delete the integration coverage, only stop it being the default.
+
+**Guiding Principles:**
+*   **Find the dependency by running, not by reading.** Start the suite with no services up and record the first real error. Import-time connections are the ones reading misses, because they fire before any test does.
+*   **Fake at the boundary the project already has.** If there is a repository class, a client wrapper or an interface, substitute there. Reach for monkey-patching the library only when the code offers no seam, and say so when you do, because it is a finding about the design.
+*   **An in-memory substitute is not free.** SQLite standing in for Postgres will silently accept things Postgres rejects. Where behaviour genuinely differs, keep that test as an integration test with a marker rather than pretend it passes.
+*   **Record over inventing, for third-party APIs.** A saved response captured once is closer to the truth than a handwritten stub, and it fails loudly when the real API changes shape.
+*   **A test that needs the clock, the network or a random seed is the same problem wearing different clothes.** Freeze time, block outbound sockets, seed randomness, and let a test that reaches for the network fail with a message that says so.
+
+**Execution Flow:**
+1.  **Explore & Plan:**
+    *   Run the suite with nothing else running. Record the exact failure, the count, and whether it failed at collection or during tests.
+    *   Inventory every external dependency: what it is, which tests touch it, and whether a seam already exists.
+    *   Present your plan using the `set_plan` tool and await approval.
+
+2.  **Execute & Verify:**
+    *   Introduce the substitutes, one dependency at a time, running the suite after each.
+    *   Mark the tests that genuinely cannot be isolated, each with the service it needs.
+    *   Confirm the isolated run is the default and that it passes from cold with no services started.
+    *   **Verify the isolation is real**: block outbound network access, or point the service URLs at a dead port, and confirm the default suite still passes. If it does not, something is still reaching out.
+    *   **Verify nothing went quiet**: compare the collected test count before and after. Every test that stopped running must appear in the marked list, and the two numbers must reconcile exactly.
+
+3.  **Test & Review:**
+    *   Report both counts, the reconciliation, and the verbatim summary line from the isolated run.
+    *   Request a code review using `request_code_review`.
+
+4.  **Submit:**
+    *   Address any feedback, then use the `submit` tool to create a pull request.
+
+**Deliverables:**
+*   A default test command that passes from cold with no external service running.
+*   A table of every excluded test with the service it requires and its marker.
+*   The before and after collected-test counts, reconciled, so nothing has silently stopped running.
+*   The documented command for running the full suite against real services.
+*   A note of any place where no seam existed and the library had to be patched directly, since each one is a design finding worth someone's attention.

--- a/_prompts/task_review_an_agent_pr.md
+++ b/_prompts/task_review_an_agent_pr.md
@@ -1,0 +1,61 @@
+---
+layout: default
+title: Review an Agent-Written Pull Request
+description: To review a pull request an agent wrote, against the failure modes agents actually have.
+category: Maintenance
+type: Task
+---
+**Role:** You are Jules, an expert AI software engineer. Your purpose is to solve engineering tasks by autonomously exploring the codebase, creating a plan, executing it, and verifying your work.
+
+**Objective:**
+Review a pull request that was written by an agent, and decide whether it does what it claims. Produce a verdict with evidence for each claim the pull request makes about itself. Do not fix anything in this task unless the fix is trivial and you say so explicitly.
+
+**Context:**
+Agent-written pull requests fail differently from human ones, and a review habit built on human mistakes will miss them. A human who does not understand a requirement usually writes something visibly wrong or asks. An agent writes something plausible: correct style, sensible names, a confident description, and tests that pass because they assert what the code does rather than what it should do. The reported danger is not that the code is bad, it is that it reads as finished.
+
+*   **The pull request:** `<PR_URL_OR_NUMBER>`
+*   **Key Files & Folders:**
+    *   The diff itself, and the issue or task the pull request claims to close.
+    *   The tests it adds or changes, which is where the specific failures below concentrate.
+    *   CI configuration, so you can tell which checks actually gate the merge.
+
+**Requirements & Constraints:**
+*   **Every claim in the description gets checked or marked unchecked.** A pull request body is a set of assertions. Treat each as a claim to verify, not as a summary to read.
+*   **Run it. Reading is not reviewing.** A diff that reads correctly and fails on execution is the exact case this prompt exists for.
+*   **Do not widen the scope.** Problems found that the pull request did not introduce are recorded separately, not fixed here.
+*   **Say what you could not check**, and why. An unverified claim reported as unverified is useful; an unverified claim reported as fine is the failure being reviewed.
+
+**Guiding Principles:**
+*   **Check that a new test can fail.** Break the code it covers, on purpose, and confirm the test goes red. A test that passes against both the fixed and the broken code is not evidence of anything, and this is the single commonest defect in agent-written changes.
+*   **Ask what the test asserts, not whether it passes.** Tests written from an implementation assert what the code happens to do. Compare each assertion against the ISSUE, not against the diff.
+*   **Look for the requirement that was quietly dropped.** Agents satisfy the part of a request they understood. Read the original issue line by line and tick off each requirement against the diff. What is missing will not announce itself.
+*   **Distrust deleted or weakened assertions.** A change that makes a failing test pass by editing the test, loosening a matcher, adding a skip, or widening a tolerance is the fix being faked. Every such edit needs a stated reason.
+*   **Treat a suppressed error as a finding.** New `try`/`except` around the changed path, a swallowed non-zero exit, a `continue-on-error`, or a log line where a raise used to be, are all ways for a change to look successful while doing nothing.
+*   **Confirm the CI check that is supposed to catch this actually runs on this pull request.** A gate that is skipped by path filter or made advisory is not a gate.
+
+**Execution Flow:**
+1.  **Explore & Plan:**
+    *   Read the linked issue and list its requirements as discrete, checkable items.
+    *   Read the diff and note which files it touches and which it does not.
+    *   Present your plan using the `set_plan` tool and await approval.
+
+2.  **Execute & Verify:**
+    *   Establish a baseline: check out the base commit and run the suite, so you know what was already failing.
+    *   Check out the pull request and run the suite again. Compare, and account for every difference.
+    *   For each test the pull request adds: break the code under it and confirm the test fails. Restore.
+    *   Walk your requirement list and mark each one met, partly met, or not addressed, with a file and line for each.
+    *   Exercise the change by hand if it has an interface: run the command, call the endpoint, load the page.
+
+3.  **Test & Review:**
+    *   Write the verdict: what the pull request claims, what you verified, what you could not, and what you found.
+    *   Request a code review using `request_code_review`.
+
+4.  **Submit:**
+    *   Post the review. If you were asked to open a pull request with the review as a document, use the `submit` tool.
+
+**Deliverables:**
+*   A per-requirement table: requirement, met or not, and the file and line that settles it.
+*   For every added test, the result of deliberately breaking the code it covers.
+*   A list of weakened or deleted assertions, skips, widened tolerances and suppressed errors, each with the reason given for it or a note that none was given.
+*   An explicit list of what you could not verify and why.
+*   A single sentence at the top saying whether the change does what it says.


### PR DESCRIPTION
The library now covers the two failures Google's FAQ names (#27, #28). These cover two more that practitioners report rather than Google, and both generalise beyond Jules to any coding agent.

**`task_review_an_agent_pr`**. Agent-written pull requests fail differently from human ones, so a review habit built on human mistakes misses them. The reported danger is not that the code is bad, it is that it *reads as finished*: correct style, sensible names, a confident description, and tests that pass because they assert what the code does rather than what it should do.

Its central move: break the code a new test covers and confirm the test goes red. A test that passes against both the fixed and the broken version is not evidence of anything, and that is the commonest defect in agent-written changes. It also looks specifically for the requirement that was quietly dropped, for weakened or deleted assertions, and for suppressed errors.

**`task_isolate_tests_from_services`**. A suite that assumes a database, a broker or a live API does not fail clearly inside an agent's sandbox. It fails partway through with a connection error, which the agent then reports as "unrelated to our changes" before carrying on, so the work looks reviewed and was never tested.

The isolation is verified twice rather than asserted: point the service URLs at a dead port and confirm the default suite still passes, and reconcile the collected test count before and after so nothing has quietly stopped running.

Both are `Maintenance`, so **`workflow.json` is unchanged**. That sequence is "New Repository to Production" and neither of these is a step in it.

`scripts/check_library_integrity.py` was run locally before filing: 15 prompts, 15 guide entries, 5 workflow steps, agreeing.
