### PR TITLE
The first sentence a visitor reads had two em dashes in it

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![GitHub stars](https://img.shields.io/github/stars/melbinjp/jules-prompts?style=social)](https://github.com/melbinjp/jules-prompts)
 
-A curated library of pre-made, machine-readable task prompts that help Jules (or any agent) — and humans — turn intent into well-scoped, verifiable engineering work.
+A curated library of machine-readable task prompts for Jules and other coding agents, including prompts for the failures agents actually have: broken setup scripts, vague issues, tests that need services the sandbox cannot start, and pull requests that only read as finished.
 
 ## Getting Started
 


### PR DESCRIPTION
The two most visible pieces of text on this repository both carried em dashes: the GitHub description, which is what appears in a search result, and the opening sentence of the README.

The description is already updated. This is the README half.

The new sentence also does something the old one did not: it says what this library is actually for. "A curated library of pre-made, machine-readable task prompts" competes on exactly the same words as the official `google-labs-code/jules-awesome-list`, which has 3,156 stars and roughly 50 prompts. Competing there is not a plan. What this library now has that no other one does, including the official one, is prompts for the failures agents actually have: broken setup scripts, vague issues, tests that need services a sandbox cannot start, and pull requests that only read as finished.

**The other twenty em dashes in this repository are deliberately left alone.** They are definition-list formatting (`` `version` - API version ``) rather than prose voice, and mechanically rewriting them would be applying a rule about outreach writing to a place it was never aimed at.
