### PR TITLE
Add a Security category, which six ignored pull requests asked for

### DIFF
--- a/PROMPTS_GUIDE.md
+++ b/PROMPTS_GUIDE.md
@@ -149,6 +149,17 @@ A suite that assumes a database, a broker or a live third-party API does not fai
 
 ---
 
+### [`task_security_review_agent_code.md`]({% link _prompts/task_security_review_agent_code.md %})
+**Purpose:** To review a change an agent wrote for the security defects agents specifically introduce.
+
+An agent asked to fix a failure finds the shortest route to the failure stopping, and that route is often to remove the thing that was objecting. The result is not a subtle logic flaw, it is a check that no longer checks, and it survives review because the diff looks like work: a scanner was added, an error was handled, a dependency was installed. This prompt targets that class directly, and its central move is to prove every check the change introduced can actually turn the build red by making it find something.
+
+**When to use it:**
+*   On any agent-written change that touches CI, dependencies, authentication, or anything handling input.
+*   Alongside `task_review_an_agent_pr.md`, which covers whether the change does what it claims; this one covers what it costs.
+
+---
+
 ### [`task_update_dependencies.md`]({% link _prompts/task_update_dependencies.md %})
 **Purpose:** To update a project's dependencies to their latest compatible versions.
 

--- a/_prompts/task_security_review_agent_code.md
+++ b/_prompts/task_security_review_agent_code.md
@@ -1,0 +1,62 @@
+---
+layout: default
+title: Security Review of Agent-Written Code
+description: To review a change an agent wrote for the security defects agents specifically introduce.
+category: Security
+type: Task
+---
+**Role:** You are Jules, an expert AI software engineer. Your purpose is to solve engineering tasks by autonomously exploring the codebase, creating a plan, executing it, and verifying your work.
+
+**Objective:**
+Review a change written by an agent for security defects, and report each with the evidence that establishes it. This is not a general audit of the project. It targets the specific ways a change goes wrong when it was produced by something optimising for a green build.
+
+**Context:**
+An agent asked to fix a failure will find the shortest route to the failure stopping. That route is often to remove the thing that was objecting. The defect this produces is not a subtle logic flaw, it is a check that no longer checks, and it is invisible in review because the diff looks like work: a scanner was added, an error was handled, a dependency was installed.
+
+*   **The change:** `<PR_URL_OR_DIFF_RANGE>`
+*   **Key Files & Folders:**
+    *   The diff, and CI configuration touched by it.
+    *   Dependency manifests and lock files.
+    *   Test fixtures, example configuration and documentation added by the change, which is where invented credentials land.
+
+**Requirements & Constraints:**
+*   **Report, do not repair**, unless a fix is one line and you say plainly that you made it. A security finding someone else has to re-derive from a patch is worth less than the finding.
+*   **Every finding carries a file, a line and why it matters.** "Potential vulnerability" is not a finding.
+*   **Rate by what an attacker gains**, not by how alarming the pattern looks. A hardcoded key in a test fixture for a local mock is not the same as one in a deployment manifest, and saying so is part of the job.
+*   **State what you did not examine.** A review that silently skipped the vendored directory reads identically to one that cleared it.
+
+**Guiding Principles:**
+*   **A check that cannot fail is the defect, not the absence of a check.** A scanner added with `continue-on-error`, a step whose exit code is discarded with `|| true`, an audit whose output is only uploaded as an artifact: each looks like security work and gates nothing. Confirm every check introduced can actually turn the build red, by making it find something.
+*   **Look for the verification that was switched off to make a request succeed.** `verify=False`, `rejectUnauthorized: false`, `--no-check-certificate`, `NODE_TLS_REJECT_UNAUTHORIZED=0`, a pinned certificate removed. These appear when something hit a TLS error and the error stopped.
+*   **Credentials in anything the change created.** Agents invent plausible values for examples, fixtures and documentation. Treat every key-shaped string as real until you have established it is not, and check whether it reached the history rather than only the working tree.
+*   **Ask where each new dependency came from.** A package that made an error go away may be a typosquat of the one intended, unmaintained, or pulled from a different registry. Check the name character by character against the import it satisfies, and check the lock file changed consistently with the manifest.
+*   **Permissions only ever widen by accident.** A workflow moved to `permissions: write-all`, a token given more scope, a mode changed to 777, a bucket or security group opened. Compare against what the change actually needs.
+*   **A swallowed exception around an authorisation path is an authorisation bypass.** Read every new `try`/`except`, `catch`, and `if err != nil` that continues, and ask what happens to the request when it fires.
+*   **Injection returns wherever a string was built.** A query, a shell command, a path or an HTML fragment assembled by concatenation or formatting is the same defect regardless of how modern the surrounding code looks.
+
+**Execution Flow:**
+1.  **Explore & Plan:**
+    *   Read the diff in full and list every file it touches, grouping them into code, configuration, CI, dependencies and fixtures.
+    *   Identify which parts of the change are on a path that handles input, credentials or permissions.
+    *   Present your plan using the `set_plan` tool and await approval.
+
+2.  **Execute & Verify:**
+    *   Walk each principle above against the diff, recording a file and line for every hit.
+    *   **Prove each new check can fail.** Introduce the thing it is supposed to catch, run it, and confirm a non-zero exit. Restore afterwards.
+    *   For every new dependency, record the exact name, version and resolved source, and compare the name against the module actually imported.
+    *   For every credential-shaped string, determine whether it is live, and whether it exists in the git history as well as the tree.
+    *   Run whatever scanners the project already has, and report their output verbatim rather than summarised.
+
+3.  **Test & Review:**
+    *   Write the findings, ordered by what an attacker gains, each with file, line, evidence and the smallest fix.
+    *   Request a code review using `request_code_review`.
+
+4.  **Submit:**
+    *   Post the review, or use the `submit` tool if you were asked to open a pull request carrying it.
+
+**Deliverables:**
+*   A findings list ordered by impact: file, line, what an attacker gains, and the smallest change that closes it.
+*   For every check the change introduced, the result of deliberately making it find something, so a check that cannot fail is caught rather than counted.
+*   A table of new dependencies: name, version, resolved source, and the import it satisfies.
+*   Every credential-shaped string found, and whether it is live and whether it is in the history.
+*   An explicit list of what you did not examine and why.


### PR DESCRIPTION
Adds a `Security` category, which the library did not have. Security appeared only as incidental constraints inside prompts about other things: "do not commit secrets" in `task_curate_repo`, "run `npm audit`" in `task_audit_repo`. Nothing was about it.

**Why this category and not another one.** The official `google-labs-code/jules-awesome-list` has 42 open pull requests, and six of them, from six different people over fourteen months, add a Security section: #19, #67, #76, #106, #107, #108. People keep independently arriving at the same gap. That is a better reason to write a prompt than my own opinion about what is missing.

**The angle is narrower than "audit this repo", on purpose.** An agent asked to fix a failure finds the shortest route to the failure stopping, and that route is often to remove the thing that was objecting. What that produces is not a subtle logic flaw. It is a check that no longer checks, and it survives review because the diff looks like work: a scanner was added, an error was handled, a dependency was installed.

So the prompt targets that class specifically:

- a check that cannot fail, added with `continue-on-error`, `|| true`, or an audit whose output is only uploaded as an artifact
- verification switched off to make a request succeed: `verify=False`, `rejectUnauthorized: false`, `NODE_TLS_REJECT_UNAUTHORIZED=0`
- credentials invented for fixtures and examples, checked against the history as well as the tree
- a new dependency compared character by character against the import it satisfies
- permissions that only ever widen by accident
- a swallowed exception around an authorisation path, which is an authorisation bypass
- injection wherever a string was built

Its central move is the same one as `task_review_an_agent_pr`: prove every check the change introduced can actually turn the build red, by making it find something.

`scripts/check_library_integrity.py` run locally before filing: 16 prompts, 16 guide entries, 5 workflow steps, agreeing.
