### PR TITLE
The site's meta description was the one place the old positioning survived

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: Jules Prompts
-description: A curated library of pre-made, machine-readable task prompts.
+description: Machine-readable task prompts for coding agents, including the failures agents actually have: broken setup scripts, vague issues, unreviewed agent PRs.
 # Needed for absolute_url, which the canonical and og:url tags in _includes/head.html use.
 url: https://jules-prompts.wecanuseai.com
 


### PR DESCRIPTION
The site's `description` in `_config.yml` still said "A curated library of pre-made, machine-readable task prompts."

That string is not decoration. `_includes/head.html` feeds it into `<meta name="description">`, `og:description` and `twitter:description`, so it is the snippet a search engine shows and the preview anyone sharing the link sees. Verified live before changing it: all three tags on the homepage carried the old text.

It is also the exact wording that competes head-on with `google-labs-code/jules-awesome-list`, which has 3,157 stars. Competing on those words is not a plan.

The README and the GitHub repo description were updated in #31 to say what the library is actually for. This one was missed, which is the same shape as watching five files that carry a version number and missing the sales copy that quotes it.

New text, 151 characters so it survives truncation, with the distinguishing part first:

> Machine-readable task prompts for coding agents, including the failures agents actually have: broken setup scripts, vague issues, unreviewed agent PRs.
