### PR TITLE
A prompt for architecture summary, from the same unmerged request as error handling

### DIFF
--- a/PROMPTS_GUIDE.md
+++ b/PROMPTS_GUIDE.md
@@ -226,6 +226,18 @@ Almost every migration is verified the same way: run it forward, once, on a deve
 
 ---
 
+### [`task_map_the_architecture.md`]({% link _prompts/task_map_the_architecture.md %})
+**Purpose:** To describe how a system actually works, derived from what runs and what imports what rather than from the folder names.
+
+Asked to describe an architecture, the obvious method is to read the directory names and the class names and assemble a tidy diagram, which will be fluent and will describe the system somebody intended to build. The folder structure is a claim about the architecture and it is the claim most likely to be stale, because renaming directories is expensive and nobody does it when the design changes: a tree still laid out in layers long after the real coupling started running sideways through one shared helper is the normal case. This prompt builds the map from things that cannot be renamed into a lie - the entry points the packaging declares, the import graph resolved rather than inferred, the boundaries that fail independently, and co-change in git history, which names the real modules whatever directory they live in. Every claim carries how it was established, and the layers are reported as not holding when they do not hold.
+
+**When to use it:**
+*   On arrival at an unfamiliar codebase, before planning any change in it.
+*   When the documented architecture and the behaviour have visibly diverged.
+*   Before a refactor, to find the coupling nobody intended rather than the layers somebody designed.
+
+---
+
 ### [`task_run_the_error_paths.md`]({% link _prompts/task_run_the_error_paths.md %})
 **Purpose:** To find the failure handling that has never once executed, by causing each failure on purpose.
 

--- a/_prompts/task_map_the_architecture.md
+++ b/_prompts/task_map_the_architecture.md
@@ -1,0 +1,45 @@
+---
+layout: default
+title: Map the Architecture
+description: To describe how the system actually works, by deriving it from what runs and what imports what rather than from the folder names.
+category: Initial Scoping
+type: Task
+---
+**Role:** You are Jules, an expert AI software engineer. Your purpose is to solve engineering tasks by autonomously exploring the codebase, creating a plan, executing it, and verifying your work.
+
+**Objective:**
+Produce a description of this system's real structure: its entry points, what calls what, where its genuine boundaries are, and where the complexity actually sits. Derive every part of it from the code and the history rather than from the layout, and say for each claim how you established it.
+
+**Context:**
+Asked to describe a system's architecture, the obvious method is to read the directory names, the class names and the README headings, and assemble a tidy diagram from them. That diagram will be fluent, confident, and a description of the system somebody intended to build.
+
+**The folder structure is a claim about the architecture, and it is the claim most likely to be stale.** Renaming directories is expensive and disruptive, so nobody does it when the design changes. A tree still laid out as `models/`, `views/`, `controllers/` long after the real coupling started running sideways through one shared helper is the normal case, not the pathological one. The layout records what the architecture was on the day the project was scaffolded.
+
+So the summary that helps is the one built from things that cannot be renamed into a lie: what the packaging declares as an entry point, what actually imports what, what fails independently, and what the history shows changes together.
+
+The tells of a description assembled from names rather than behaviour are consistent. A layer appears in the diagram that no import ever crosses. A "service" turns out to be one function called from one place. A module named for a concept contains three unrelated things that were put there because it was the least-bad location. A dependency arrow points the way the design intended and the code goes the other way.
+
+**Git history is the part nobody uses and it names the real modules.** Files that change in the same commits, repeatedly, are one unit of work whatever directory they live in. Two directories that never appear in a commit together are genuinely separate, and that is worth more than any diagram.
+
+*   **Key Files & Folders:**
+    *   Packaging and process definitions: `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`, `Makefile`, `Dockerfile`, `docker-compose`, and the CI workflow, which is often the only honest list of how the thing is invoked.
+    *   The import graph itself, resolved rather than inferred from paths.
+    *   Anything crossing a process, a network, a queue or a database, because those are boundaries that fail independently.
+    *   Configuration and environment variables, which show what the system expects the world to provide.
+    *   `git log` over the whole tree, for co-change rather than for messages.
+
+**Requirements & Constraints:**
+*   **Find the entry points; do not guess them.** Console scripts, `main` functions, server bindings, `CMD`, cron definitions, the commands CI runs. Then RUN one and note what it touched, because an entry point nobody can start is a finding.
+*   **Build the import graph from imports.** Resolve them. A path that looks like a layer boundary is not one until you have shown that nothing crosses it, and "nothing crosses it" is a claim you check rather than assert.
+*   **Name the real boundaries, which are the ones that fail separately.** A process, a network hop, a database, a third-party API. Two packages in one process that import each other freely are one component with a naming convention, however the folders are arranged.
+*   **Use co-change to find the modules.** Which files appear together in commits, and which never do. Report the surprises, since agreement with the folder layout is the uninteresting outcome and disagreement is the finding.
+*   **Say how you know, per claim.** "Resolved the import", "ran it", "appears in 14 of 20 commits touching X", "declared in pyproject". A structural description without provenance cannot be told apart from a plausible guess, and plausible guesses about architecture are exactly what this task produces by default.
+*   **Do not draw a diagram the code does not support.** If the layers do not hold, say the layers do not hold. A clean picture of a system that is not clean is worse than no picture, because it will be believed and planned against.
+*   **Report what you could not establish.** Dynamic dispatch, reflection, plugin loading and configuration-driven wiring defeat static reading. Name them; they are where the surprises live.
+
+**Guiding Principles:**
+*   **Derive, do not describe.** Every element of the map should trace to something executed, resolved or counted. The moment a sentence rests on a directory being named after a concept, it has stopped being architecture and become a reading of somebody's filing system.
+*   **The interesting structure is the coupling nobody intended.** Anyone can find the layers that were designed. The value is in the shared mutable helper, the module everything imports, the cycle between two packages that are documented as independent.
+*   **Follow the data, not the call stack.** Where state lives, who writes it and who reads it explains more about a system than which function calls which. Two components that never call each other but write the same table are coupled.
+*   **Count things.** Files per directory, imports in and out per module, commits per path, how many places construct the central object. Numbers survive rewording; adjectives do not.
+*   **A good map lets somebody predict.** The test is whether a reader could now say where a change to one behaviour would land, and what would break. If it does not support that, it is a description of the repository rather than of the system.


### PR DESCRIPTION
Upstream PR 43 asked for automation, error handling, documentation and architecture summary together and none of it merged there. Documentation and error handling are done; this is the third.

**The premise:** the obvious method produces a confident description of the wrong system. Read the directory names and the class names, assemble a diagram, and you have described what somebody intended to build.

**The folder structure is a claim about the architecture, and it is the claim most likely to be stale.** Renaming directories is expensive, so nobody does it when the design changes. A tree still laid out in layers long after the real coupling started running sideways through one shared helper is the normal case.

So the map comes from things that cannot be renamed into a lie:

- Entry points the packaging declares, with one of them actually run.
- The import graph resolved, not inferred from paths. A path that looks like a layer boundary is not one until nothing has been shown to cross it.
- Boundaries defined as what fails independently. Two packages in one process that import each other freely are one component with a naming convention.
- Co-change from `git log`, which names the real modules whatever directory they live in. Agreement with the folder layout is the uninteresting outcome; disagreement is the finding.

Every claim carries how it was established, and it is told to report that the layers do not hold when they do not - a clean picture of a system that is not clean will be believed and planned against.

`scripts/check_library_integrity.py` green: 23 prompts, 23 guide entries, workflow agrees, config parses.